### PR TITLE
fix!: change checkout_repository default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ jobs:
     build-src-package:
         runs-on: ubuntu-latest
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
             - name: Create package
               uses: minvws/action-generic-build-package@v1
               with:
@@ -34,12 +37,11 @@ In this basic example, the workflow is executed automatically on push of tags.
 
 The action has the following inputs:
 
-- `include_paths`: A space-separated list with files and directories to include in the package relative to the working_directory.
-- `package_file_name`: Name of the package (without extension), for example: `nl-example-package`.
-- `working_directory`: The base directory containing the source code, only required if it does not need to be the root folder.
-- `version_json_path`: The location where version.json needs to be stored. For example `public/version.json`. Default: `version.json`.
-- `checkout_repository`: Boolean value inside string to enable or disable checkout repository
-  in the action. For example `"true"` or `"false"`. Default `"true"`.
+- `package_file_name`: Name of the package (without extension), for example: `nl-example-package`. Required.
+- `include_paths`: A space-separated list with files and directories to include in the package, relative to the `working_directory`. Optional, default: `"."`.
+- `working_directory`: The base directory containing the source code, relative to the project root. Optional, default: `"."`.
+- `version_json_path`: The location where version.json needs to be stored. For example `public/version.json`. Optional, default: `version.json`.
+- `checkout_repository`: Whether to checkout the repository in the action. Boolean string, for example `"true"`. Optional, default: `"false"`.
 
 ### Result
 

--- a/action.yml
+++ b/action.yml
@@ -20,13 +20,13 @@ inputs:
   checkout_repository:
     description: "Whether to checkout the repository (true or false)."
     required: false
-    default: 'true'
+    default: "false"
 
 runs:
   using: "composite"
   steps:
     - name: Checkout code
-      if: inputs.checkout_repository == 'true'
+      if: inputs.checkout_repository == "true"
       uses: actions/checkout@v5
 
     - name: Extract version from tag


### PR DESCRIPTION
Change the default for `checkout_repository` to `"false"` and update the README example to include a checkout step.